### PR TITLE
feat: C-workflow - push to issue branch 觸發 CI

### DIFF
--- a/.github/workflows/c-workflow.yml
+++ b/.github/workflows/c-workflow.yml
@@ -1,0 +1,57 @@
+name: C-workflow（CI）
+
+on:
+  push:
+    branches:
+      - 'issue-*'
+
+permissions:
+  contents: read
+
+jobs:
+  backend-ci:
+    name: Backend CI（Ruff + Pytest）
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Ruff lint
+        run: ruff check .
+
+      - name: Pytest
+        run: pytest tests/ -v
+
+  frontend-ci:
+    name: Frontend CI（ESLint）
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: ESLint
+        run: npm run lint


### PR DESCRIPTION
## Summary
- 新增 C-workflow（CI）workflow 檔案
- push 到 `issue-*` branch 時自動觸發 Backend CI（Ruff + Pytest）與 Frontend CI（ESLint）

## Test plan
- [ ] merge 後確認 `.github/workflows/c-workflow.yml` 存在於 main
- [ ] push 到 `issue-*` branch 確認兩個 CI job 正常觸發