### PR TITLE
feat(c-workflow): notify PG to set up test env on PR open

### DIFF
--- a/.github/workflows/c-workflow.yml
+++ b/.github/workflows/c-workflow.yml
@@ -4,9 +4,14 @@ on:
   push:
     branches:
       - 'issue-*'
+  pull_request:
+    types: [opened]
+    branches:
+      - main
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   backend-ci:
@@ -55,3 +60,43 @@ jobs:
 
       - name: ESLint
         run: npm run lint
+
+  notify-test-env:
+    name: Notify PG to Set Up Test Environment
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.pull_request.head.ref, 'issue-')
+
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            const match = branch.match(/^issue-(\d+)/);
+            const issueNum = match ? match[1] : '?';
+
+            const body = `🧪 **PR 已建立，請設定測試環境**
+
+## PG 測試環境 Checklist
+
+- [ ] 本地啟動後端：\`cd backend && uvicorn main:app --reload\`
+- [ ] 本地啟動前端：\`cd frontend && npm run dev\`
+- [ ] 確認資料庫連線正常
+- [ ] 依照 TestPlan 逐一執行測試案例，填寫測試報告
+
+測試報告請存放於 \`PG測試報告/issue-${issueNum}.md\`（N = PG Issue 編號）。`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });


### PR DESCRIPTION
## Summary

- 新增 `pull_request: opened` trigger（target: main）
- 新增 `pull-requests: write` permission
- 新增 `notify-test-env` job：當 `issue-*` 分支開 PR 時，自動用 GitHub App token 在 PR 留言，提醒 PG 設定測試環境並填寫測試報告

## Test plan

- [ ] 從 `issue-*` 分支對 main 開 PR，確認 `notify-test-env` job 觸發
- [ ] 確認 PR 留言包含正確的 issue 編號（從 branch name 提取）
- [ ] 確認非 `issue-*` 分支的 PR 不觸發此 job

🤖 Generated with [Claude Code](https://claude.com/claude-code)