### PR TITLE
fix: chore-workflow 改用 GitHub App token

### DIFF
--- a/.github/workflows/chore-workflow.yml
+++ b/.github/workflows/chore-workflow.yml
@@ -5,7 +5,7 @@ on:
     types: [labeled]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   create-chore-branch:
@@ -13,10 +13,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create chore branch
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const issue = context.payload.issue;
             const issueNumber = issue.number;


### PR DESCRIPTION
## Summary
- chore-workflow 從 `GITHUB_TOKEN` 改用 GitHub App token
- 與其他 workflow 保持一致，避免 org 層級 token 權限限制

## Test plan
- [ ] 建立 Chore Issue + 加 chore label，確認自動建立 `chore-{N}-{slug}` 分支

🤖 Generated with [Claude Code](https://claude.com/claude-code)