### PR TITLE
docs: 更新 README 路徑、版本與 CLAUDE.md AI 指引

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,3 +27,24 @@ cd frontend && npm install
 
 Commit message 格式：`{type}({scope}): 說明`
 可用 type：`feat` | `fix` | `docs` | `refactor` | `test` | `chore`
+
+## AI 實作指引（PG 階段）
+
+收到 PG Issue 後，依序讀取：
+
+| 需要什麼 | 去哪裡找 |
+|----------|---------|
+| 實作範圍 | PG Issue body「實作範圍」欄位 |
+| API 規格 | `P1-design/Spec/` |
+| 畫面規格 | `P1-design/Prototype/` |
+| 本次異動 delta | `P1-design/TestPlan/issue-{SD#}-diff.md` |
+| 商業邏輯背景 | `P1-analysis/issue-{SA#}/business-logic.md` |
+| 測試標準 | `P1-design/TestPlan/issue-{SD#}.md` |
+
+**pytest 數量 ≥ TestPlan 案例數**，每個 test function 標注對應的 TestPlan ID：
+
+```python
+def test_create_leave_request(client, db_session, auth_headers):
+    """對應 TestPlan issue-5 T1"""
+    ...
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # P1-code — 系統開發（PG／AI）
 
-P1 產品的前後端程式碼庫。 React + FastAPI，由 PG 或 AI 依據 SD 規格實作。
+> [← 回到 P1 總導覽](https://github.com/MPinfo-Co/P1-project#readme)
+
+P1 產品的前後端程式碼庫。React 19（JavaScript）+ FastAPI，由 PG 或 AI 依據 SD 規格實作。
 
 ## 在四 Repo 流程中的角色
 
@@ -15,7 +17,7 @@ P1-project（PM）→ P1-analysis（SA）→ P1-design（SD）
 
 ```
 P1-code/
-├── frontend/                     # React 18 + Vite + TypeScript + Tailwind CSS
+├── frontend/                     # React 19 + Vite + JavaScript + Tailwind CSS
 ├── backend/                      # Python FastAPI + SQLAlchemy + PostgreSQL
 ├── PG測試報告/
 │   └── issue-{N}.md              # 測試報告（系統建立框架，PG 填寫結果）
@@ -49,4 +51,8 @@ P1-code/
 
 ## 完整工作流程規範
 
-請參考 [P1-project/docs/github-workflow/quick-start.md](https://github.com/MPinfo-Co/P1-project/blob/main/docs/github-workflow/quick-start.md)
+請參考 [P1-project/docs/workflow/quick-start.md](https://github.com/MPinfo-Co/P1-project/blob/main/docs/workflow/quick-start.md)
+
+## 環境設定
+
+新成員首次設定請見 [SETUP.md](SETUP.md)


### PR DESCRIPTION
## Summary
- README.md: 新增 back link、更新 React 18 → React 19 / TypeScript → JavaScript、修正 quick-start.md 路徑、新增 SETUP.md 連結
- CLAUDE.md: 新增 AI 實作指引章節（PG 階段讀取關聯鏈說明）

## Test plan
- [ ] README.md 連結可正常跳轉
- [ ] CLAUDE.md 內容與 CLAUDE.md（根目錄）一致