### PR TITLE
fix(backend): allow Vercel origins in CORS

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,11 @@ app = FastAPI(title="MP-Box API")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=[
+        "http://localhost:5173",
+        "https://p1-code.vercel.app",
+        "https://*.vercel.app",
+    ],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- CORS `allow_origins` 加入 `https://p1-code.vercel.app` 及 `https://*.vercel.app`
- 修正前端 Vercel 部署打後端時被 CORS 擋住的問題

## Test plan
- [ ] Production 及 Preview 環境登入不再出現伺服器錯誤