### PR TITLE
chore(fn_navbar): 更名 model 檔案 fn_auth_sidebar → fn_navbar

### DIFF
--- a/backend/app/api/navigation.py
+++ b/backend/app/api/navigation.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.db.connector import get_db
-from app.db.models.fn_auth_sidebar import Function, FunctionFolder
+from app.db.models.fn_navbar import Function, FunctionFolder
 from app.utils.util_store import AuthContext, authenticate
 
 router = APIRouter(prefix="/api/navigation", tags=["navigation"])

--- a/backend/app/api/roles.py
+++ b/backend/app/api/roles.py
@@ -14,7 +14,7 @@ from app.api.schema.roles import (
     RoleUpdateOut,
 )
 from app.db.connector import get_db
-from app.db.models.fn_auth_sidebar import Function, RoleFunction
+from app.db.models.fn_navbar import Function, RoleFunction
 from app.db.models.fn_user_role import Role, User, UserRole
 from app.logger_utils import get_system_logger
 from app.utils.util_store import AuthContext, authenticate

--- a/backend/app/api/user.py
+++ b/backend/app/api/user.py
@@ -19,7 +19,7 @@ from app.api.schema.user import (
 )
 from app.db.connector import get_db
 from app.db.models import User, UserRole
-from app.db.models.fn_auth_sidebar import Function, RoleFunction
+from app.db.models.fn_navbar import Function, RoleFunction
 from app.logger_utils import get_system_logger
 from app.utils.util_store import AuthContext, authenticate, hash_password
 

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -5,5 +5,5 @@ which is what Alembic autogenerate consumes via `target_metadata = Base.metadata
 """
 
 from .fn_user_role import Role as Role, TokenBlacklist as TokenBlacklist, User as User, UserRole as UserRole
-from .fn_auth_sidebar import FunctionFolder as FunctionFolder, Function as Function, RoleFunction as RoleFunction
+from .fn_navbar import FunctionFolder as FunctionFolder, Function as Function, RoleFunction as RoleFunction
 from .fn_expert_security_event import *  # noqa: F401, F403

--- a/backend/app/db/models/fn_navbar.py
+++ b/backend/app/db/models/fn_navbar.py
@@ -1,4 +1,4 @@
-"""ORM models for fn_auth sidebar: tb_function_folder, tb_functions, tb_role_function."""
+"""ORM models for fn_navbar: tb_function_folder, tb_functions, tb_role_function."""
 
 from sqlalchemy import Boolean, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
@@ -7,7 +7,7 @@ from .base import Base
 
 
 class FunctionFolder(Base):
-    """Sidebar 目錄，管理功能分組的名稱與展開狀態。"""
+    """Navbar 目錄，管理功能分組的名稱與展開狀態。"""
 
     __tablename__ = "tb_function_folder"
 
@@ -21,7 +21,7 @@ class FunctionFolder(Base):
 
 
 class Function(Base):
-    """系統功能清單，每筆對應一個 Sidebar 功能項目。"""
+    """系統功能清單，每筆對應一個 Navbar 功能項目。"""
 
     __tablename__ = "tb_functions"
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -11,7 +11,7 @@ from fastapi.testclient import TestClient
 
 from app.db.connector import get_db
 from app.main import app
-from app.db.models.fn_auth_sidebar import Function, FunctionFolder, RoleFunction
+from app.db.models.fn_navbar import Function, FunctionFolder, RoleFunction
 from app.db.models.fn_user_role import Role, TokenBlacklist, User, UserRole
 
 TEST_DATABASE_URL = "sqlite:///:memory:"

--- a/backend/tests/test_auth_me_api.py
+++ b/backend/tests/test_auth_me_api.py
@@ -7,7 +7,7 @@ Covers test spec IDs T6 and T7 from _fn_auth_test_api.md.
 from sqlalchemy.orm import sessionmaker
 
 from app.db.models.fn_user_role import Role, User, UserRole
-from app.db.models.fn_auth_sidebar import Function, FunctionFolder, RoleFunction
+from app.db.models.fn_navbar import Function, FunctionFolder, RoleFunction
 from app.utils.util_store import create_access_token, hash_password
 
 

--- a/backend/tests/test_navigation_api.py
+++ b/backend/tests/test_navigation_api.py
@@ -4,7 +4,7 @@ Tests for GET /api/navigation API.
 
 from sqlalchemy.orm import sessionmaker
 
-from app.db.models.fn_auth_sidebar import Function, FunctionFolder, RoleFunction
+from app.db.models.fn_navbar import Function, FunctionFolder, RoleFunction
 from app.db.models.fn_user_role import Role, User, UserRole
 from app.utils.util_store import create_access_token, hash_password
 

--- a/backend/tests/test_role_api.py
+++ b/backend/tests/test_role_api.py
@@ -11,7 +11,7 @@ Tests for fn_role APIs:
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.utils.util_store import create_access_token, hash_password
-from app.db.models.fn_auth_sidebar import Function, FunctionFolder, RoleFunction
+from app.db.models.fn_navbar import Function, FunctionFolder, RoleFunction
 from app.db.models.fn_user_role import Role, User, UserRole
 
 

--- a/backend/tests/test_user_api.py
+++ b/backend/tests/test_user_api.py
@@ -11,7 +11,7 @@ Tests for fn_user APIs:
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.utils.util_store import create_access_token, hash_password
-from app.db.models.fn_auth_sidebar import Function, FunctionFolder, RoleFunction
+from app.db.models.fn_navbar import Function, FunctionFolder, RoleFunction
 from app.db.models.fn_user_role import Role, User, UserRole
 
 


### PR DESCRIPTION
## Summary
- `backend/app/db/models/fn_auth_sidebar.py` → `fn_navbar.py`
- 更新 9 個檔案的 import 路徑（`app.db.models.fn_auth_sidebar` → `app.db.models.fn_navbar`）
- 更新 `fn_navbar.py` 內 3 處 docstring（sidebar → navbar）

## Notes
- Python class 名稱（`FunctionFolder`、`Function`、`RoleFunction`）為通用命名，不動
- `__tablename__` 為通用命名，不動，無需新增 migration
- Alembic revision ID `c167_fn_auth_sidebar` 不動
- 前端無相關引用，不動
- 相關 52 個測試全部通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)